### PR TITLE
Expand README with stack + getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,101 @@
-# README #
+# Trivit
 
-Trivit is an mobile application that allows to create lists of tally marks. Trivit uses intuitive user actions in order to add or remove a list and add, remove and reset tally marks. Also, it comes in beautiful colors.
+A tally counter for iOS and watchOS. Tap to count up, swipe to count down,
+swipe across to reset. Comes in 10 flat colors. No analytics, no accounts,
+no dependencies.
 
-### Available gestures (current) ###
+Originally Objective-C / UIKit. Fully rewritten in Swift / SwiftUI / SwiftData
+in January 2026.
 
-- Swipe right to reset counter value
-- Swipe left to decrease counter value
-- Tap to increase the counter value
+## Gestures
 
-### Technical Notes ###
+- Tap a row to **increment** the counter
+- Swipe **left** to decrement
+- Swipe **right** to **reset** to zero
+- Long-press for the context menu (rename, change color, delete)
 
-This app has been fully rewritten in Swift/SwiftUI (iOS 17+) as of January 2026.
+Haptic feedback on every interaction; warning haptic on destructive actions.
 
-### Who do I talk to? ###
+## Stack
 
-* Wouter Devriendt (wouter@ballooninc.be)
-* Pieterjan Criel (crielpieterjan@gmail.com)
-* Balloon Inc support (support@ballooninc.be)
+| Component          | Tech                                  |
+| ------------------ | ------------------------------------- |
+| UI                 | SwiftUI                               |
+| Persistence        | SwiftData (`@Model`, `@Query`)        |
+| Architecture       | Lightweight MVVM; views own their state |
+| Watch app          | watchOS 10+, WatchConnectivity        |
+| Language           | Swift 5+                              |
+| Minimum iOS / watchOS | 17.0 / 10.0                        |
+| Dependencies       | None — pure Apple frameworks          |
+
+See [`ARCHITECTURE.md`](ARCHITECTURE.md) for a deeper walkthrough of the
+project layout, data model, and patterns.
+
+## Getting started
+
+You need: macOS with **Xcode 15+** and an Apple Developer account (for
+device testing).
+
+```bash
+# 1. Clone
+git clone https://github.com/BalloonInc/trivit.git
+cd trivit
+
+# 2. Open in Xcode
+open trivit.xcodeproj   # or trivit.xcworkspace if you see one
+```
+
+In Xcode:
+
+1. Pick the **trivit** scheme and a simulator (iPhone 17 Pro works fine).
+2. Hit **⌘R**. It should build and launch the app — no extra config needed
+   for the simulator.
+3. To run on a real device:
+   - Open **Signing & Capabilities** for the `trivit` target.
+   - Set your own **Team** (this repo's Team ID is for the original
+     maintainers; you'll need to replace it).
+   - Change the **bundle identifier** to something unique under your team,
+     e.g. `com.yourname.trivit`.
+   - Plug in your iPhone, select it as the run destination, ⌘R.
+
+Useful command-line build / run:
+
+```bash
+# Build for a simulator
+xcodebuild -scheme trivit \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build
+
+# Install on a connected device (replace the device UDID)
+xcrun devicectl device install app --device <UDID> \
+  ~/Library/Developer/Xcode/DerivedData/trivit-*/Build/Products/Debug-iphoneos/trivit.app
+```
+
+## Watch app
+
+The watchOS companion is in `trivit Watch App/`. It mirrors the iPhone's list
+and lets you increment from the wrist. Cross-device sync is via
+WatchConnectivity, with App Groups configured for shared SwiftData storage
+(group: `group.com.wouterdevriendt.trivit`).
+
+If you fork, you'll need to either:
+
+- create your own App Group identifier on the Apple Developer Portal and
+  swap it into the entitlements, or
+- run iPhone-only and skip the watch target.
+
+## TestFlight & releases
+
+The `fastlane/` directory has the release automation. There are GitHub
+Actions workflows for TestFlight internal, TestFlight external, and App
+Store. See `fastlane/README.md` and `CLAUDE.md` for details.
+
+## Maintainers
+
+- Wouter Devriendt — wouter@ballooninc.be
+- Pieterjan Criel — crielpieterjan@gmail.com
+- Balloon Inc support — support@ballooninc.be
+
+## License
+
+See [`LICENSE`](LICENSE) — Polyform Noncommercial 1.0.0. Free for personal
+and non-commercial use.


### PR DESCRIPTION
## Summary

The current README is ~5 lines (essentially: \"tally counter app, here are the gestures\"). This expands it without throwing anything away, so somebody landing on github.com/BalloonInc/trivit can:

- Understand what the app does and the gesture vocabulary
- See the stack at a glance (SwiftUI / SwiftData / no dependencies, iOS 17+ / watchOS 10+)
- Build and run it locally — both via Xcode (the easy path) and from the command line (\`xcodebuild\` + \`xcrun devicectl\`)
- Know what they need to change to run on their own device (Team ID, bundle identifier)
- Find the watchOS companion notes and the App Groups identifier
- Find the fastlane / GitHub Actions release pipeline

Content sourced from ARCHITECTURE.md, CLAUDE.md, and what's in the project structure today — nothing invented.

## Test plan

- [ ] README renders cleanly on github.com/BalloonInc/trivit
- [ ] Build commands work as shown (Xcode ⌘R, \`xcodebuild\` for simulator)
- [ ] Watch / App Groups note is accurate
- [ ] No broken links to ARCHITECTURE.md / LICENSE / fastlane/README.md